### PR TITLE
Add proper namespaces to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,12 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,12 +161,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "memchr"
-version = "2.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-dsa"
@@ -288,66 +276,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.145"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "sha3"
@@ -480,9 +408,6 @@ dependencies = [
  "ml-dsa",
  "ml-kem",
  "rand",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
  "sha3",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,9 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2"
-serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.6"
-serde_json = "1.0"
-getrandom = { version = "0.2.16", features = ["js"] }
 ml-dsa = "0.0.4"
-rand = "0.8"
-ml-kem = "0.2.1"
 sha3 = "0.10.8"
+ml-kem = { version = "0.2.1", features = ["deterministic"] }
+wasm-bindgen = "0.2"
+rand = "0.8"
+getrandom = { version = "0.2.16", features = ["js"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 160
+wrap_comments = true

--- a/src/mldsa.rs
+++ b/src/mldsa.rs
@@ -8,6 +8,9 @@ pub struct MlDsaKeypair {
 }
 
 #[wasm_bindgen]
+pub struct MlDsa;
+
+#[wasm_bindgen]
 impl MlDsaKeypair {
     #[wasm_bindgen(getter, js_name = "publicKey")]
     pub fn public_key(&self) -> Vec<u8> {
@@ -20,85 +23,103 @@ impl MlDsaKeypair {
     }
 }
 
-/// Generates a verifying (public), and a corresponding signing (private)
-/// [ML-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf) key.
-#[wasm_bindgen(js_name = "mldsaKeygen")]
-pub fn keygen() -> MlDsaKeypair {
-    let mut rng = rand::rngs::OsRng;
-    let keypair = MlDsa87::key_gen(&mut rng);
-    let public_key = keypair.verifying_key().clone();
-    let private_key = keypair.signing_key().clone();
+#[wasm_bindgen]
+impl MlDsa {
+    fn keygen_random() -> MlDsaKeypair {
+        let mut rng = rand::rngs::OsRng;
 
-    MlDsaKeypair {
-        public_key: public_key.encode().to_vec(),
-        private_key: private_key.encode().to_vec(),
+        let keypair = MlDsa87::key_gen(&mut rng);
+
+        MlDsaKeypair {
+            public_key: keypair.verifying_key().encode().to_vec(),
+            private_key: keypair.signing_key().encode().to_vec(),
+        }
     }
-}
 
-/// The signing algorithm [ML-DSA.Sign](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf#algorithm.2)
-/// takes a signing (private) key, a message, and a context string as an input.
-///
-/// This function implements the default "hedged" version of ML-DSA signing, it uses randomness internally to generate
-/// a 256-bit random seed. This makes the signatures non-deterministic, and safer against side-channel attacks.
-///
-/// ### Parameters
-/// * `private_key`: Signing key generated with `mldsaKeygen`
-/// * `message`: Message that is to be signed
-/// * `context`: Optional context string (up to 255 bytes), treated as an empty string if omitted
-#[wasm_bindgen(js_name = "mldsaSign")]
-pub fn sign(
-    #[wasm_bindgen(js_name = "privateKey")] private_key: &[u8],
-    message: &[u8],
-    context: Option<Vec<u8>>,
-) -> Result<Vec<u8>, String> {
-    let mut rng = rand::rngs::OsRng;
-    let private_key = EncodedSigningKey::<MlDsa87>::try_from(private_key)
-        .map_err(|e| format!("Could not get encoded signing key from private_key: {e}"))?;
+    fn keygen_deterministic(seed: &[u8]) -> Result<MlDsaKeypair, String> {
+        if seed.len() != 32 {
+            return Err("The seed is expected to be exactly 32 bytes".into());
+        }
 
-    let context = if context.is_none() {
-        b"".to_vec()
-    } else {
-        context.unwrap()
-    };
+        let seed = ml_dsa::B32::try_from(&seed[0..32]).map_err(|e| format!("Could not build seed: {e}"))?;
+        let keypair = MlDsa87::key_gen_internal(&seed);
 
-    let signature = SigningKey::<MlDsa87>::decode(&private_key)
-        .sign_randomized(message, &context, &mut rng)
-        .unwrap()
-        .encode();
+        Ok(MlDsaKeypair {
+            public_key: keypair.verifying_key().encode().to_vec(),
+            private_key: keypair.signing_key().encode().to_vec(),
+        })
+    }
 
-    Ok(signature.to_vec())
-}
+    /// Generates a verifying (public), and a corresponding signing (private)
+    /// [ML-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf) key.
+    ///
+    /// This function takes in an optional seed of **exactly** 32 bytes, which
+    /// can be used to generate a key pair deterministically.
+    /// [ML-DSA.KeyGen_internal](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf#algorithm.6)
+    /// algorithm.
+    ///
+    /// If no seed is passed, `KeyGen` will generate the key pair randomly, as specified in the
+    /// [ML-KEM.KeyGen](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf#algorithm.1)
+    /// algorithm.
+    #[wasm_bindgen(js_name = "KeyGen")]
+    pub fn keygen_internal(seed: Option<Vec<u8>>) -> Result<MlDsaKeypair, String> {
+        match seed {
+            Some(seed) => Self::keygen_deterministic(seed.as_slice()),
+            None => Ok(Self::keygen_random()),
+        }
+    }
 
-/// The verification algorithm [ML-DSA.Verify](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf#algorithm.3)
-/// takes a verifying (public) key, signature, and a context string as input. This function returns `true` if the signature
-/// is valid with respect to the message, context, and public key, and `false` if the signature is invalid.
-///
-/// ### Parameters
-/// * `public_key`: Signing key generated with `mldsaKeygen`
-/// * `message`: Signed message
-/// * `signature`: The signature that is to be verified
-/// * `context`: Optional context string (up to 255 bytes), treated as an empty string if omitted
-#[wasm_bindgen(js_name = "mldsaVerify")]
-pub fn verify(
-    #[wasm_bindgen(js_name = "publicKey")] public_key: &[u8],
-    message: &[u8],
-    signature: &[u8],
-    context: Option<Vec<u8>>,
-) -> Result<bool, String> {
-    let encoded_public_key = ml_dsa::EncodedVerifyingKey::<MlDsa87>::try_from(public_key)
-        .map_err(|e| format!("Could not encode verifying key: {e}"))?;
-    let public_key = ml_dsa::VerifyingKey::<MlDsa87>::decode(&encoded_public_key);
-    let encoded_signature = EncodedSignature::<MlDsa87>::try_from(signature)
-        .map_err(|e| format!("Could not encode signature: {e}"))?;
+    /// The signing algorithm [ML-DSA.Sign](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf#algorithm.2)
+    /// takes a signing (private) key, a message, and a context string as an input.
+    ///
+    /// This function implements the default "hedged" version of ML-DSA signing, it uses randomness internally to generate
+    /// a 256-bit random seed. This makes the signatures non-deterministic, and safer against side-channel attacks.
+    ///
+    /// ### Parameters
+    /// * `private_key`: Signing key generated with `mldsaKeygen`
+    /// * `message`: Message that is to be signed
+    /// * `context`: Optional context string (up to 255 bytes), treated as an empty string if omitted
+    #[wasm_bindgen(js_name = "Sign")]
+    pub fn sign(#[wasm_bindgen(js_name = "privateKey")] private_key: &[u8], message: &[u8], context: Option<Vec<u8>>) -> Result<Vec<u8>, String> {
+        let mut rng = rand::rngs::OsRng;
+        let private_key =
+            EncodedSigningKey::<MlDsa87>::try_from(private_key).map_err(|e| format!("Could not get encoded signing key from private_key: {e}"))?;
 
-    let context = if context.is_none() {
-        Vec::new()
-    } else {
-        context.unwrap()
-    };
+        let context = context.unwrap_or_default();
 
-    match Signature::<MlDsa87>::decode(&encoded_signature) {
-        Some(sigma) => Ok(public_key.verify_with_context(message, &context, &sigma)),
-        None => Err("Could not decode signature".to_string()),
+        let signature = SigningKey::<MlDsa87>::decode(&private_key)
+            .sign_randomized(message, &context, &mut rng)
+            .unwrap()
+            .encode();
+
+        Ok(signature.to_vec())
+    }
+
+    /// The verification algorithm [ML-DSA.Verify](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf#algorithm.3)
+    /// takes a verifying (public) key, signature, and a context string as input. This function returns `true` if the signature
+    /// is valid with respect to the message, context, and public key, and `false` if the signature is invalid.
+    ///
+    /// ### Parameters
+    /// * `public_key`: Signing key generated with `mldsaKeygen`
+    /// * `message`: Signed message
+    /// * `signature`: The signature that is to be verified
+    /// * `context`: Optional context string (up to 255 bytes), treated as an empty string if omitted
+    #[wasm_bindgen(js_name = "Verify")]
+    pub fn verify(
+        #[wasm_bindgen(js_name = "publicKey")] public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+        context: Option<Vec<u8>>,
+    ) -> Result<bool, String> {
+        let encoded_public_key = ml_dsa::EncodedVerifyingKey::<MlDsa87>::try_from(public_key).map_err(|e| format!("Could not encode verifying key: {e}"))?;
+        let public_key = ml_dsa::VerifyingKey::<MlDsa87>::decode(&encoded_public_key);
+        let encoded_signature = EncodedSignature::<MlDsa87>::try_from(signature).map_err(|e| format!("Could not encode signature: {e}"))?;
+
+        let context = context.unwrap_or_default();
+
+        match Signature::<MlDsa87>::decode(&encoded_signature) {
+            Some(sigma) => Ok(public_key.verify_with_context(message, &context, &sigma)),
+            None => Err("Could not decode signature".to_string()),
+        }
     }
 }

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -17,6 +17,9 @@ pub struct MlKemEncapsulation {
 }
 
 #[wasm_bindgen]
+pub struct MlKem;
+
+#[wasm_bindgen]
 impl MlKemKeypair {
     #[wasm_bindgen(getter, js_name = "encapsulationKey")]
     pub fn encapsulation_key(&self) -> Vec<u8> {
@@ -42,62 +45,84 @@ impl MlKemEncapsulation {
     }
 }
 
-/// Generates an encapsulation (public), and a corresponding decapsulation (private)
-/// [ML-KEM](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf) key.
-#[wasm_bindgen(js_name = "mlkemKeyGen")]
-pub fn keygen() -> MlKemKeypair {
-    let mut rng = rand::rngs::OsRng;
-    let (decapsulation_key, encapsulation_key) = MlKem1024::generate(&mut rng);
-    MlKemKeypair {
-        encapsulation_key: encapsulation_key.as_bytes().to_vec(),
-        decapsulation_key: decapsulation_key.as_bytes().to_vec(),
+#[wasm_bindgen]
+impl MlKem {
+    fn key_gen_random() -> MlKemKeypair {
+        let mut rng = rand::rngs::OsRng;
+        let (decapsulation_key, encapsulation_key) = MlKem1024::generate(&mut rng);
+        MlKemKeypair {
+            encapsulation_key: encapsulation_key.as_bytes().to_vec(),
+            decapsulation_key: decapsulation_key.as_bytes().to_vec(),
+        }
     }
-}
 
-/// The encapsulation algorithm [ML-KEM.Encaps](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf#algorithm.20)
-/// accepts an encapsulation (public) key as input, generates randomness internally, and outputs an ML-KEM ciphertext and
-/// shared secret.
-///
-/// The ciphertext can safely be sent to the owner of the corresponding decapsulation (private) key, who can then use it
-/// to derive the same shared secret. The shared secret itself is a **secret** and shall be treated as such.
-#[wasm_bindgen(js_name = "mlkemEncaps")]
-pub fn encaps(
-    #[wasm_bindgen(js_name = "encapsulationKey")] encapsulation_key: &[u8],
-) -> Result<MlKemEncapsulation, String> {
-    let encoded_encapsulation_key =
-        Encoded::<EncapsulationKey<MlKem1024Params>>::try_from(encapsulation_key)
+    fn key_gen_deterministic(seed: &[u8]) -> Result<MlKemKeypair, String> {
+        if seed.len() != 64 {
+            return Err("The seed is expected to be exactly 64 bytes".into());
+        }
+
+        let d = ml_kem::B32::try_from(&seed[0..32]).map_err(|e| format!("Could not build 'd' from seed[0..32]: {e}"))?;
+        let z = ml_kem::B32::try_from(&seed[32..64]).map_err(|e| format!("Could not build 'z' from seed[0..32]: {e}"))?;
+
+        let (decapsulation_key, encapsulation_key) = MlKem1024::generate_deterministic(&d, &z);
+        Ok(MlKemKeypair {
+            encapsulation_key: encapsulation_key.as_bytes().to_vec(),
+            decapsulation_key: decapsulation_key.as_bytes().to_vec(),
+        })
+    }
+
+    /// Generates an encapsulation (public), and a corresponding decapsulation (private)
+    /// [ML-KEM](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf) key.
+    ///
+    /// This function takes in an optional seed of **exactly** 64 bytes, which
+    /// is then split into `d` and `z`, and passed to the
+    /// [ML-KEM.KeyGen_internal](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf#algorithm.16)
+    /// algortithm to generate a key pair deterministically.
+    ///
+    /// If no seed is passed, `KeyGen` will generate the key pair with a randomly generated seed,
+    /// as specified in the [ML-KEM.KeyGen](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf#algorithm.19)
+    /// algorithm.
+    #[wasm_bindgen(js_name = "KeyGen")]
+    pub fn keygen(seed: Option<Vec<u8>>) -> Result<MlKemKeypair, String> {
+        match seed {
+            Some(seed) => Self::key_gen_deterministic(seed.as_slice()),
+            None => Ok(Self::key_gen_random()),
+        }
+    }
+
+    /// The encapsulation algorithm [ML-KEM.Encaps](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf#algorithm.20)
+    /// accepts an encapsulation (public) key as input, generates randomness internally, and outputs an ML-KEM ciphertext and
+    /// shared secret.
+    ///
+    /// The ciphertext can safely be sent to the owner of the corresponding decapsulation (private) key, who can then use it
+    /// to derive the same shared secret. The shared secret itself is a **secret** and shall be treated as such.
+    #[wasm_bindgen(js_name = "Encaps")]
+    pub fn encaps(#[wasm_bindgen(js_name = "encapsulationKey")] encapsulation_key: &[u8]) -> Result<MlKemEncapsulation, String> {
+        let encoded_encapsulation_key = Encoded::<EncapsulationKey<MlKem1024Params>>::try_from(encapsulation_key)
             .map_err(|e| format!("Could not get encoded encapsulation key from bytes: {e}"))?;
-    let encapsulation_key =
-        EncapsulationKey::<MlKem1024Params>::from_bytes(&encoded_encapsulation_key);
-    let mut rng = rand::rngs::OsRng;
-    let (ciphertext, shared_secret) = encapsulation_key
-        .encapsulate(&mut rng)
-        .map_err(|e| format!("Could not encapsulate: {e:?}"))?;
+        let encapsulation_key = EncapsulationKey::<MlKem1024Params>::from_bytes(&encoded_encapsulation_key);
+        let mut rng = rand::rngs::OsRng;
+        let (ciphertext, shared_secret) = encapsulation_key.encapsulate(&mut rng).map_err(|e| format!("Could not encapsulate: {e:?}"))?;
 
-    Ok(MlKemEncapsulation {
-        ciphertext: ciphertext.to_vec(),
-        shared_secret: shared_secret.to_vec(),
-    })
-}
+        Ok(MlKemEncapsulation {
+            ciphertext: ciphertext.to_vec(),
+            shared_secret: shared_secret.to_vec(),
+        })
+    }
 
-/// The decapsulation algorithm [ML-KEM.Decaps](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf#algorithm.21)
-/// accepts a decapsulation (private) key and an ML-KEM ciphertext as input, does not use any randomness, and outputs a shared
-/// secret.
-#[wasm_bindgen(js_name = "mlkemDecaps")]
-pub fn decaps(
-    #[wasm_bindgen(js_name = "decapsulationKey")] decapsulation_key: &[u8],
-    ciphertext: &[u8],
-) -> Result<Vec<u8>, String> {
-    let encoded_decapsulation_key =
-        Encoded::<DecapsulationKey<MlKem1024Params>>::try_from(decapsulation_key)
+    /// The decapsulation algorithm [ML-KEM.Decaps](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf#algorithm.21)
+    /// accepts a decapsulation (private) key and an ML-KEM ciphertext as input, does not use any randomness, and outputs a shared
+    /// secret.
+    #[wasm_bindgen(js_name = "Decaps")]
+    pub fn decaps(#[wasm_bindgen(js_name = "decapsulationKey")] decapsulation_key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, String> {
+        let encoded_decapsulation_key = Encoded::<DecapsulationKey<MlKem1024Params>>::try_from(decapsulation_key)
             .map_err(|e| format!("Could not get encoded decapsulation key from bytes: {e}"))?;
-    let decapsulation_key =
-        DecapsulationKey::<MlKem1024Params>::from_bytes(&encoded_decapsulation_key);
-    let ciphertext_array = Ciphertext::<Kem<MlKem1024Params>>::try_from(ciphertext)
-        .map_err(|e| format!("Could not decode ciphertext: {e}"))?;
-    let shared_secret = decapsulation_key
-        .decapsulate(&ciphertext_array)
-        .map_err(|e| format!("Could not decapsulate: {e:?}"))?;
+        let decapsulation_key = DecapsulationKey::<MlKem1024Params>::from_bytes(&encoded_decapsulation_key);
+        let ciphertext_array = Ciphertext::<Kem<MlKem1024Params>>::try_from(ciphertext).map_err(|e| format!("Could not decode ciphertext: {e}"))?;
+        let shared_secret = decapsulation_key
+            .decapsulate(&ciphertext_array)
+            .map_err(|e| format!("Could not decapsulate: {e:?}"))?;
 
-    Ok(shared_secret.to_vec())
+        Ok(shared_secret.to_vec())
+    }
 }

--- a/src/sha3.rs
+++ b/src/sha3.rs
@@ -1,23 +1,24 @@
-use sha3::{Digest, Sha3_512};
+use sha3::{Digest, Sha3_512 as sha3_512};
 use wasm_bindgen::prelude::*;
 
-/// Computes a SHA-3-512 hash of the input data.
-///
-/// SHA-3 (Secure Hash Algorithm 3) is a cryptographic hash function standardized by NIST
-/// in FIPS 202. SHA-3-512 produces a 512-bit (64-byte) hash digest.
-///
-/// # References
-///
-/// * [NIST FIPS 202: SHA-3 Standard](https://csrc.nist.gov/pubs/fips/202/final)
-/// * [SHA-3 on Wikipedia](https://en.wikipedia.org/wiki/SHA-3)
-#[wasm_bindgen(js_name = "sha3Hash512")]
-pub fn sha3_512(data: &[u8]) -> Vec<u8> {
-    let mut hasher = Sha3_512::new();
-    hasher.update(data);
-    hasher.finalize().to_vec()
-}
+#[wasm_bindgen]
+pub struct Sha3_512;
 
-#[test]
-fn testst() {
-    eprintln!("{:02x?}", sha3_512(b"as"));
+#[wasm_bindgen]
+impl Sha3_512 {
+    /// Computes a SHA-3-512 hash of the input data.
+    ///
+    /// SHA-3 (Secure Hash Algorithm 3) is a cryptographic hash function standardized by NIST
+    /// in FIPS 202. SHA-3-512 produces a 512-bit (64-byte) hash digest.
+    ///
+    /// # References
+    ///
+    /// * [NIST FIPS 202: SHA-3 Standard](https://csrc.nist.gov/pubs/fips/202/final)
+    /// * [SHA-3 on Wikipedia](https://en.wikipedia.org/wiki/SHA-3)
+    #[wasm_bindgen(js_name = "sha3Hash512")]
+    pub fn hash(data: &[u8]) -> Vec<u8> {
+        let mut hasher = sha3_512::new();
+        hasher.update(data);
+        hasher.finalize().to_vec()
+    }
 }


### PR DESCRIPTION
Closes #3

This adds proper namespacing to primitives by wrapping them in empty Rust structs.

before:
```ts
wasm.mlkemKeyGen();
```
after:
```ts
wasm.MlKem.KeyGen();
```